### PR TITLE
fix: clear console.log, displaying api key

### DIFF
--- a/src/lib/connectors/magicConnectConnector.ts
+++ b/src/lib/connectors/magicConnectConnector.ts
@@ -48,7 +48,6 @@ export class MagicConnectConnector extends Connector {
       });
 
       this.provider = this.magic.rpcProvider;
-      console.log('initializeMagicInstance', this.magic);
     }
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Deletes logging of magic instance 
- **What is the current behavior?** (You can also link to an open issue here)
Magic instance gets logged in console, displaying api key.
- **What is the new behavior (if this is a feature change)?**
No more magic instance log. 
- **Other information**:
